### PR TITLE
Bugfix for transitions being reversed every other time

### DIFF
--- a/Components/LiquidRoute/LiquidAnimator.jsx
+++ b/Components/LiquidRoute/LiquidAnimator.jsx
@@ -34,11 +34,6 @@ export default class LiquidAnimator extends Component {
       animation.animation,
       animationOptions
     ).onfinish = () => {
-      const reversedAnimation = animation.animation.reverse();
-      this.container.animate(reversedAnimation, {
-        duration: 1,
-        fill: 'forwards'
-      });
       cb();
     };
   }


### PR DESCRIPTION
This fixes an issue where, since the exit animation is run in reverse after it first runs (https://github.com/prateekbh/liquid-route/blob/master/Components/LiquidRoute/LiquidAnimator.jsx#L37), the second time it runs, the DOM nodes are out of place and the enter animation is reversed.

Before
------
![2017-07-14-22-26-53](https://user-images.githubusercontent.com/6805589/28235848-bcb30158-68e4-11e7-87d9-2ae704adf2a2.gif)

After
------
![ezgif-2-78f545e8b7](https://user-images.githubusercontent.com/6805589/28235849-bfe84d2e-68e4-11e7-9dcb-0d767fa2f33d.gif)
